### PR TITLE
Change reference from the reviewer console to the CodeGuru console

### DIFF
--- a/doc_source/create-github-association.md
+++ b/doc_source/create-github-association.md
@@ -7,7 +7,7 @@ We recommend creating a new GitHub user \(for example, *MyCodeGuruUser*\) and us
 
 **To create a GitHub repository association**
 
-1. Open the Amazon CodeGuru Reviewer console at [https://console\.aws\.amazon\.com/codeguru/reviewer/home](https://console.aws.amazon.com/codeguru/reviewer/home)\.
+1. Open the Amazon CodeGuru console at [https://console\.aws\.amazon\.com/codeguru/home](https://console.aws.amazon.com/codeguru/home)\.
 
 1. In the navigation pane, choose **Repositories**\. 
 


### PR DESCRIPTION
This is no longer a valid URL and there is no reviewer-specific page on the console

*Issue #, if available:* Clicking on the `https://console.aws.amazon.com/codeguru/reviewer/home` link on the page takes me to a broken URL.

*Description of changes:* Fixed to the default console home.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
